### PR TITLE
Provide and conflict 'arch-update'

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,13 +5,14 @@
 pkgname=gnome-shell-extension-crystal-update
 _pkgname=crystal-update
 pkgver=51
-pkgrel=1
+pkgrel=2
 pkgdesc="Convenient indicator for Crystal Linux updates in GNOME Shell."
 arch=('any')
 url="https://github.com/crystal-linux/${_pkgname}"
 license=('GPL3')
 depends=('gnome-shell' 'ame')
-conflicts=('gnome-shell-extensions-git')
+provides=('gnome-shell-extension-arch-update')
+conflicts=('gnome-shell-extension-arch-update' 'gnome-shell-extensions-git')
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
 sha256sums=('4b680d65c3946e0f9fbe43dd5523fee7368209362eff28af225261226d1d7f6c')
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# pkgbuild.gnome-shell-extension-crystal-update
+# gnome-shell-extension-crystal-update
 PKGBUILD for our fork of https://github.com/RaphaelRochet/arch-update


### PR DESCRIPTION
Hi,

Since `crystal-update` is basically a fork of `arch-update` that provides the same features and share the same "gschemas", we should make them conflict with each other.

Also, it will make the switch from one to another easier for current `onyx` users when `onyx` v1.2 will be released, since they'll just have to `ame upg` and accept to replace `arch-update` by `crystal-update` (since they'll conflict with each other).

What do you think?